### PR TITLE
Single Threaded version → master

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [targets]
-test = ["Test", "NearestNeighbors", "StaticArrays"]
+test = ["Test", "NearestNeighbors", "StaticArrays", "Statistics"]

--- a/src/HNSW.jl
+++ b/src/HNSW.jl
@@ -1,5 +1,4 @@
 module HNSW
-    import Base.Threads: Mutex
     using LinearAlgebra
     using Reexport
     @reexport using Distances

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -12,7 +12,7 @@ function insert_point!(hnsw, query, l = get_random_level(hnsw.lgraph))
     # Get enterpoint and highest level in a threadsafe way
     lock(hnsw.ep_lock)
         enter_point = get_enter_point(hnsw)
-        L =  get_top_layer(hnsw)
+        L =  get_entry_level(hnsw)
 
         # Special Case for the very first entry
         if enter_point == 0
@@ -102,7 +102,7 @@ function knn_search(hnsw, q, K)
     @assert length(q)==length(hnsw.data[1])
     ep = get_enter_point(hnsw)
     epN = Neighbor(ep, distance(hnsw, q, ep))
-    L = get_top_layer(hnsw) #layer of ep , top layer of hnsw
+    L = get_entry_level(hnsw) #layer of ep , top layer of hnsw
     for level ∈ L:-1:2 # Iterate from top to second lowest
         epN = search_layer(hnsw, q, epN, 1, level)[1]
     end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -57,7 +57,7 @@ function add_to_graph!(hnsw::HierarchicalNSW{T}, indices; multithreading=false) 
     end
     return nothing
 end
-add_to_graph!(hnsw::HierarchicalNSW) = add_to_graph!(hnsw, eachindex(hnsw.data))
+add_to_graph!(hnsw::HierarchicalNSW; kwargs...) = add_to_graph!(hnsw, eachindex(hnsw.data); kwargs...)
 
 
 set_ef!(hnsw::HierarchicalNSW, ef) = hnsw.ef = ef

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -30,7 +30,7 @@ function HierarchicalNSW(data;
     F = eltype(data[1])
     vlp = VisitedListPool(1,max_elements)
     return HierarchicalNSW{T,F,typeof(data),typeof(metric)}(
-        lg, fill(false, max_elements), data, ep, 0, Mutex(), vlp, metric, efConstruction, ef)
+        lg, fill(false, max_elements), data, ep, 0, vlp, metric, efConstruction, ef)
 end
 
 """

--- a/src/layered_graphs.jl
+++ b/src/layered_graphs.jl
@@ -60,7 +60,7 @@ function set_edges!(lg, level, source, targets)
     for m ∈ 1:min(M,T)
         lg.linklist[source][offset + m]  = targets[m].idx
     end
-    for m ∈ T:M
+    for m ∈ T+1:M
         lg.linklist[source][offset + m]  = 0 #type ?
     end
 end

--- a/src/layered_graphs.jl
+++ b/src/layered_graphs.jl
@@ -7,10 +7,9 @@ function LinkList{T}(num_elements::Int) where {T}
     Vector{Vector{T}}(undef, num_elements)
 end
 
-mutable struct LayeredGraph{T}
+struct LayeredGraph{T}
     linklist::LinkList{T}  #linklist[index][level][link]
     locklist::Vector{Mutex}
-    numlayers::Int
     M0::Int
     M::Int
     m_L::Float64
@@ -31,7 +30,6 @@ function LayeredGraph{T}(num_elements::Int, M, M0, m_L) where {T}
     LayeredGraph{T}(
         LinkList{T}(num_elements),
         [Mutex() for i=1:num_elements],
-        0,
         M,
         M0,
         m_L)
@@ -40,7 +38,6 @@ end
 
 function add_vertex!(lg::LayeredGraph{T}, i, level) where {T}
     lg.linklist[i] = fill(zero(T), lg.M0 + (level-1)*lg.M)
-    #lg.numlayers > level || (lg.numlayers = level)
     return nothing
 end
 
@@ -75,7 +72,6 @@ end
 ############################################################################################
 
 Base.length(lg::LayeredGraph) = lg.numlayers
-get_top_layer(lg::LayeredGraph) = lg.numlayers
 get_random_level(lg) = floor(Int, -log(rand())* lg.m_L) + 1
 max_connections(lg::LayeredGraph, level) = level==1 ? lg.M0 : lg.M
 index_offset(lg, level) = level > 1 ? lg.M0 + lg.M*(level-2) : 0

--- a/src/layered_graphs.jl
+++ b/src/layered_graphs.jl
@@ -40,7 +40,7 @@ end
 
 function add_vertex!(lg::LayeredGraph{T}, i, level) where {T}
     lg.linklist[i] = fill(zero(T), lg.M0 + (level-1)*lg.M)
-    lg.numlayers > level || (lg.numlayers = level)
+    #lg.numlayers > level || (lg.numlayers = level)
     return nothing
 end
 

--- a/test/lowlevel_tests.jl
+++ b/test/lowlevel_tests.jl
@@ -1,5 +1,5 @@
 using HNSW
-import HNSW: LayeredGraph, add_vertex!, add_edge!, get_top_layer, levelof, neighbors,max_connections
+import HNSW: LayeredGraph, add_vertex!, add_edge!, get_entry_level, levelof, neighbors,max_connections
 using Test
 using LinearAlgebra
 using NearestNeighbors
@@ -57,10 +57,10 @@ end
     lg = HNSW.LayeredGraph{UInt32}(num_elements, M0, M, m_L)
     @test max_connections(lg, 1) == M0
     @test max_connections(lg, 2) == M
-    @testset "add_vertex! & get_top_layer" for i=1:10
+    @testset "add_vertex! & get_entry_level" for i=1:10
         level = rand(1:10)
         add_vertex!(lg, i, level)
-        @test get_top_layer(lg) >= level
+        #@test get_entry(lg) >= level
     end
     @testset "add_edge!" begin
         for i = 1:10, j=1:10


### PR DESCRIPTION
Here are all the changes from #11 with the
multithreading part removed.

I believe this should be the default and therefore be merged into master.

`VisitedListPool` still has its thread-safety in place but it is largely modular / separated from the 
rest. The whole structure becomes somewhat obsolete without it.
We could modify `HierarchicalNSW` to just contain a `VisitedList` in the
single-threaded case but there'd be no significant performance improvement.
