### PR TITLE
Removed poolguard from VisitedListPool

### DIFF
--- a/src/HNSW.jl
+++ b/src/HNSW.jl
@@ -1,5 +1,4 @@
 module HNSW
-    import Base.Threads: Mutex
     using LinearAlgebra
     using Reexport
     @reexport using Distances


### PR DESCRIPTION
This is a small pull that removes the `poolguard::Threads.Mutex` field from the `VisitedListPool` and makes the latter non-mutable (its fields are still mutable). Removing the `Mutex` field make the model serializable and should have not impact on the behavior.

By the way, the `nomulti` branch fails the `Compare To NearestNeighbors.jl` test set most often than not (probably some bug crept in). 