### PR TITLE
allow dynamically adding new data to HNSW

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -88,9 +88,7 @@ function add!(hnsw::HierarchicalNSW, newdata::Vector{D}) where D
     extend!(hnsw.vlp, endindex)
 
     # Now add the new data at end of our existing data
-    for d in newdata
-        push!(hnsw.data, d)
-    end
+    append!(hnsw.data, newdata)
 
     # Now we can add the datum to the graph, as usual
     add_to_graph!(hnsw, startindex:endindex)

--- a/src/layered_graphs.jl
+++ b/src/layered_graphs.jl
@@ -7,6 +7,12 @@ function LinkList{T}(num_elements::Int) where {T}
     Vector{Vector{T}}(undef, num_elements)
 end
 
+function extend!(linklist::LinkList{T}, newindex::Integer) where {T}
+    for _ in (length(linklist)+1):newindex
+        push!(linklist, T[])
+    end
+end
+
 struct LayeredGraph{T}
     linklist::LinkList{T}  #linklist[index][level][link]
     M0::Int
@@ -14,6 +20,9 @@ struct LayeredGraph{T}
     m_L::Float64
 end
 
+function extend!(lgraph::LayeredGraph{T}, newindex::Integer) where {T}
+    extend!(lgraph.linklist, newindex)
+end
 
 
 """

--- a/test/dynamically_adding_new_data.jl
+++ b/test/dynamically_adding_new_data.jl
@@ -1,0 +1,51 @@
+using HNSW
+#using Random
+using Test
+
+@testset "Dynamically add new data" begin
+    # To get two comparable HNSW objects, even if starting from same
+    # data, we need to ensure same random seed.
+    #seed = rand(1:100000)
+    #Random.seed!(seed)
+
+    dim = 5
+    num_elements = 100
+    num_queries = 100
+    origdata = [rand(Float32, dim) for n ∈ 1:num_elements]
+
+    hnsw = HierarchicalNSW(origdata)
+    add_to_graph!(hnsw)
+
+    # Now add new data
+    newdata = [rand(Float32, dim) for n ∈ 1:num_elements]
+    alldata = vcat(deepcopy(origdata), deepcopy(newdata))
+    HNSW.add!(hnsw, newdata)
+
+    @test length(hnsw.data) == 2*num_elements
+
+    # Although we would frequently get the same answer if we create a new HNSW
+    # from all data above, in one go, this cannot be guaranteed. The reason
+    # is that when we add in several "batches" we are not going to visit the
+    # same previous data points and thus the layers might look slightly different.
+    # We thus skip the testing below, since exactly equal results cannot be guaranteed.
+    
+    # Make one HNSW from all the datapoints in one go.
+    # When we query these two HNSW they should always give same response.
+    # Random.seed!(seed)
+    # hnsw2 = HierarchicalNSW(alldata)
+    # add_to_graph!(hnsw2)
+# 
+    # queries = [rand(Float32, dim) for n ∈ 1:num_queries]
+    # for query in queries
+    #     k = rand(1:1)
+    #     # Probably no need to reset the seed below but let's be sure
+    #     Random.seed!(seed)
+    #     idxs1, dists1 = knn_search(hnsw, query, k)
+    #     Random.seed!(seed)
+    #     idxs2, dists2 = knn_search(hnsw2, query, k)
+    #     for ki in 1:k
+    #         @test idxs1[ki] == idxs2[ki]
+    #         @test dists1[ki] == dists2[ki]
+    #     end
+    # end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ ti = time()
 
 include("lowlevel_tests.jl")
 include("compare_nearestneighbors.jl")
+include("dynamically_adding_new_data.jl")
 ti = time() - ti
 println("\nTest took total time of:")
 println(round(ti, digits=3), " seconds or ", round(ti/60, digits=3), " minutes")


### PR DESCRIPTION
This is not very pretty and can probably be shortened but I really needed to be able to dynamically add data to a HNSW object and this PR should allow this. I think it might also be useful to others.

I tried to also test that when adding incrementally one would then get exactly the same results as if creating from all the data in a single batch. However, it seems this cannot be guaranteed, even if the same random seed is used, since the order of visiting nodes will be different and thus the connections might not be exactly the same. I'm not sure though so would be great with feedback on if this is actually the right way.