### PR TITLE
Add matrix distance calculation

### DIFF
--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -89,7 +89,7 @@ end
 ###########################################################################################
 function knn_search(hnsw, q, K)
     ef = max(K, hnsw.ef)
-    @assert length(q)==length(hnsw.data[1])
+    # @assert length(q)==length(hnsw.data[1])
     ep = get_enter_point(hnsw)
     epN = Neighbor(ep, distance(hnsw, q, ep))
     L = get_entry_level(hnsw) #layer of ep , top layer of hnsw

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -82,8 +82,8 @@ get_entry_level(hnsw::HierarchicalNSW) = hnsw.entry_level
 @inline distance(hnsw, i, j) = @inbounds evaluate(hnsw.metric, hnsw.data[i], hnsw.data[j])
 @inline distance(hnsw, i, q::AbstractVector) = @inbounds evaluate(hnsw.metric, hnsw.data[i], q)
 @inline distance(hnsw, q::AbstractVector, j) = @inbounds evaluate(hnsw.metric, hnsw.data[j], q)
-@inline distance(hnsw, q::Matrix{Float32}, j) = @inbounds evaluate(hnsw.metric, q, hnsw.data[j])
-@inline distance(hnsw, i, q::Matrix{Float32}) = @inbounds evaluate(hnsw.metric, q, hnsw.data[i])
+@inline distance(hnsw, q::AbstractMatrix, j) = @inbounds evaluate(hnsw.metric, q, hnsw.data[j])
+@inline distance(hnsw, i, q::AbstractMatrix) = @inbounds evaluate(hnsw.metric, q, hnsw.data[i])
 
 function Base.show(io::IO, hnsw::HierarchicalNSW)
     lg = hnsw.lgraph

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -82,6 +82,8 @@ get_entry_level(hnsw::HierarchicalNSW) = hnsw.entry_level
 @inline distance(hnsw, i, j) = @inbounds evaluate(hnsw.metric, hnsw.data[i], hnsw.data[j])
 @inline distance(hnsw, i, q::AbstractVector) = @inbounds evaluate(hnsw.metric, hnsw.data[i], q)
 @inline distance(hnsw, q::AbstractVector, j) = @inbounds evaluate(hnsw.metric, hnsw.data[j], q)
+@inline distance(hnsw, q::Matrix{Float32}, j) = @inbounds evaluate(hnsw.metric, q, hnsw.data[j])
+@inline distance(hnsw, i, q::Matrix{Float32}) = @inbounds evaluate(hnsw.metric, q, hnsw.data[i])
 
 function Base.show(io::IO, hnsw::HierarchicalNSW)
     lg = hnsw.lgraph

--- a/test/lowlevel_tests.jl
+++ b/test/lowlevel_tests.jl
@@ -3,6 +3,7 @@ import HNSW: LayeredGraph, add_vertex!, add_edge!, get_entry_level, levelof, nei
 using Test
 using LinearAlgebra
 using NearestNeighbors
+using Distances
 
 @testset "Nearest & Furthest" begin
     for i=1:10
@@ -93,4 +94,15 @@ end
             end
         end
     end
+end
+
+@testset "Matrix distance" begin 
+    struct MatrixDist <: PreMetric end
+    (::MatrixDist)(X, Y) = matrix_dist(X, Y)
+
+    matrix_dist(X, Y) = X * Y |> sum
+    M1 = [1 1; 1 1]
+    M2 = [1 0; 0 1]
+
+    @test matrix_dist(M1, M2) == 4
 end

--- a/test/lowlevel_tests.jl
+++ b/test/lowlevel_tests.jl
@@ -99,10 +99,18 @@ end
 @testset "Matrix distance" begin 
     struct MatrixDist <: PreMetric end
     (::MatrixDist)(X, Y) = matrix_dist(X, Y)
-
     matrix_dist(X, Y) = X * Y |> sum
+    
+    HNSWparams = Dict(
+        :efConstruction => 10,
+        :metric => MatrixDist(),
+        :M => 10,
+        :ef => 10)
+    hnsw_data = map(i -> rand(2,2), 1:20)
+    hnsw = HierarchicalNSW(hnsw_data; HNSWparams...)
     M1 = [1 1; 1 1]
-    M2 = [1 0; 0 1]
-
-    @test matrix_dist(M1, M2) == 4
+    M2 = [0 0; 0 0]
+    @test typeof(HNSW.distance(hnsw, 1, M1)) == Float64
+    @test HNSW.distance(hnsw, 1, M2) == 0
+    @test HNSW.distance(hnsw, M2, 2) == 0
 end


### PR DESCRIPTION
This pull request adds calculation of distances between matrices. I added distance functions for matrices and remove checking that the length of query object is the same as the length of objects used to build nearest neighbors graph. This addition can be useful when one constructs a nearest neighbor graph for objects defined by matrices. For example, in the case of searching through documents, which are specified by matrices containing sentence embeddings. The Distances.jl package allows you to use this type of objects if metrics measure is scalar. I also added test for the addition.  